### PR TITLE
Handle invalid post id

### DIFF
--- a/lib/my_blog_web/controllers/post_controller.ex
+++ b/lib/my_blog_web/controllers/post_controller.ex
@@ -7,7 +7,14 @@ defmodule MyBlogWeb.PostController do
   end
 
   def show(conn, %{"id" => id}) do
-    {:ok, post} = MyBlog.PostRepo.get(id)
-    render conn, "show.html", post: post
+    case MyBlog.PostRepo.get(id) do
+      {:ok, post} ->
+        render(conn, "show.html", post: post)
+      {:error, _} ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(MyBlogWeb.ErrorView)
+        |> render("404.html")
+    end
   end
 end


### PR DESCRIPTION
When a post with the requested id is not found a Phoenix exception is
thrown.

It's of help to show a way to handle the case of non-existing post. A
case statement is sufficient to achieve this.